### PR TITLE
Disable quantize for rir, add offset_in_samples and revert slurm.pl

### DIFF
--- a/libaueffect/audio.py
+++ b/libaueffect/audio.py
@@ -217,7 +217,7 @@ def append_wav(x, path):
 
 
 
-def write_wav(x, path, sample_rate=16000, avoid_clipping=False, save_as_one_file=True):
+def write_wav(x, path, sample_rate=16000, avoid_clipping=False, save_as_one_file=True, quantize=True):
     x = copy.deepcopy(x)
 
     if avoid_clipping:
@@ -225,7 +225,8 @@ def write_wav(x, path, sample_rate=16000, avoid_clipping=False, save_as_one_file
         if m > np.iinfo(np.int16).max / np.abs(np.iinfo(np.int16).min):
             x /= ( m * np.abs(np.iinfo(np.int16).min) / np.iinfo(np.int16).max )
 
-    x = quantize_wav(x)
+    if quantize:
+        x = quantize_wav(x)
     if x.ndim > 1:
         x = x.T
 

--- a/libaueffect/noise_generators/gensphnoise.py
+++ b/libaueffect/noise_generators/gensphnoise.py
@@ -2,7 +2,7 @@
 
 import libaueffect
 
-import pyrirgen
+# import pyrirgen
 
 import numpy as np
 import math

--- a/libaueffect/room_simulators/genrir.py
+++ b/libaueffect/room_simulators/genrir.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
 import libaueffect
 
-import pyrirgen
+try:
+    # https://github.com/Marvin182/rir-generator
+    #    That repository does no longer exist.
+    from pyrirgen import generateRir
+except ImportError:
+    # https://github.com/boeddeker/rirgen
+    #     My fork of Marvin182/rir-generator changed to be a package, i.e. added setup.py and so on.
+    from rirgen.pyrirgen import generate_rir
+
+    def generateRir(L, s, R, soundVelocity, fs, reverbTime, nSamples):
+        return generate_rir(L, s, R, sound_velocity=soundVelocity, fs=fs, reverb_time=reverbTime, n_samples=nSamples)
+
 
 import numpy as np
 import math
@@ -188,7 +199,7 @@ class RandomRirGenerator(object):
             dist_3d = np.linalg.norm(s - r)
             height = s[2] - r[2]
             
-            h0 = np.array(pyrirgen.generateRir(L, s, R, soundVelocity=self._sound_velocity, fs=self._fs, reverbTime=rt, nSamples=rirlen))
+            h0 = np.array(generateRir(L, s, R, soundVelocity=self._sound_velocity, fs=self._fs, reverbTime=rt, nSamples=rirlen))
 
             #import matplotlib.pyplot as plt
             #plt.figure()

--- a/scripts/run_meetings.sh
+++ b/scripts/run_meetings.sh
@@ -35,7 +35,7 @@ function print_usage_and_exit {
 }
 
 
-nj=32  # default parallel jobs
+nj=4  # default parallel jobs
 
 while true
 do 

--- a/scripts/run_meetings.sh
+++ b/scripts/run_meetings.sh
@@ -170,6 +170,6 @@ fi
 if [ -v save_image ]; then
     opts="$opts --save_image"
 fi
-${gen_cmd} JOB=1:${nj} ${splitdir}/log/mixlog.JOB.log \
+${gen_cmd} --mem 10GB JOB=1:${nj} ${splitdir}/log/mixlog.JOB.log \
     python $mixer $opts --iolist ${splitdir}/mixspec.JOB.json --cancel_dcoffset --random_seed JOB --sample_rate 16000 --log ${splitdir}/mixlog.JOB.json --mixers_configfile $roomcfg
 python $mergejson $(for j in $(seq ${nj}); do echo ${splitdir}/mixlog.${j}.json; done) > $mixlog

--- a/tools/gen_mixspec_mtg.py
+++ b/tools/gen_mixspec_mtg.py
@@ -159,6 +159,7 @@ def give_timing(sess, overlap_time_ratio=0.3, sil_prob=0.2, sil_dur=[0.3, 2.0], 
         offset -= ot
         actual_overlap_time += max(ot, 0)
         utt['offset'] = offset
+        utt['offset_in_samples'] = int(offset * utt['sampling_rate'])
         offset += utt['length_in_seconds']
 
         last_utt_end[spkr] = offset

--- a/tools/kaldi_utils/slurm.pl
+++ b/tools/kaldi_utils/slurm.pl
@@ -178,11 +178,12 @@ option mem=0          # Do not add anything to qsub_opts
 option num_threads=* --cpus-per-task $0 --ntasks-per-node=1
 option num_threads=1 --cpus-per-task 1  --ntasks-per-node=1 # Do not add anything to qsub_opts
 default gpu=0
-option gpu=0 #-p shared
-option gpu=* -p gpu --gres=gpu:$0 # --time 4:0:0  # this has to be figured out
+option gpu=0 -p shared
+option gpu=* -p gpu --gres=gpu:$0 --time 4:0:0  # this has to be figured out
+EOF
+
 # note: the --max-jobs-run option is supported as a special case
 # by slurm.pl and you don't have to handle it in the config file.
-EOF
 
 # Here the configuration options specified by the user on the command line
 # (e.g. --mem 2G) are converted to options to the qsub system as defined in
@@ -414,9 +415,7 @@ if ($array_job == 0) { # not an array job
 }
 print Q "exit \$[\$ret ? 1 : 0]\n"; # avoid status 100 which grid-engine
 print Q "## submitted with:\n";       # treats specially.
-#$qsub_cmd .= " $qsub_opts --open-mode=append -e ${queue_logfile} -o ${queue_logfile} $queue_array_opt $queue_scriptfile >>$queue_logfile 2>&1";
-#$qsub_cmd .= " --nodelist=gqxx-01-101 -p 2080ti --gres=gpu:1 --open-mode=append -e ${queue_logfile} -o ${queue_logfile} $queue_array_opt $queue_scriptfile >>$queue_logfile 2>&1";
-$qsub_cmd .= " --exclude=cqxx-01-00[1-6],cqxx-01-01[7-8],gqxx-01-[003,011,120],gqxx-01-048,gqxx-01-119 --qos qd3 $qsub_opts --open-mode=append -e ${queue_logfile} -o ${queue_logfile} $queue_array_opt $queue_scriptfile >>$queue_logfile 2>&1";
+$qsub_cmd .= " $qsub_opts --open-mode=append -e ${queue_logfile} -o ${queue_logfile} $queue_array_opt $queue_scriptfile >>$queue_logfile 2>&1";
 print Q "# $qsub_cmd\n";
 if (!close(Q)) { # close was not successful... || die "Could not close script file $shfile";
   die "Failed to close the script file (full disk?)";

--- a/tools/mixaudio_mtg.py
+++ b/tools/mixaudio_mtg.py
@@ -79,7 +79,9 @@ def main(args):
                         libaueffect.write_wav(dt[key], 
                                               filename, 
                                               avoid_clipping=False, 
-                                              save_as_one_file=(not args.save_each_channel_in_onefile))
+                                              save_as_one_file=(not args.save_each_channel_in_onefile),
+                                              quantize=False if key.startswith('rir') else True,
+                                              )
 
                 input_info = [{'path': os.path.abspath(f['path']), 
                                'speaker_id': f['speaker_id'], 

--- a/tools/mixaudio_mtg.py
+++ b/tools/mixaudio_mtg.py
@@ -42,7 +42,7 @@ def main(args):
                 print('[{}/{} ({:.3f}%)]'.format(i+1, len(iolist), i / len(iolist)))
 
                 infiles = [os.path.abspath(f['path']) for f in iofiles['inputs']]
-                offsets = [int(args.sample_rate * f['offset']) for f in iofiles['inputs']]
+                offsets = [f['offset_in_samples'] for f in iofiles['inputs']]
                 spkr_labs = [f['speaker_id'] for f in iofiles['inputs']]
                 outfile = os.path.abspath(iofiles['output'])
 
@@ -85,7 +85,8 @@ def main(args):
 
                 input_info = [{'path': os.path.abspath(f['path']), 
                                'speaker_id': f['speaker_id'], 
-                               'offset': f['offset'], 
+                               'offset': f['offset'],
+                               'offset_in_samples': f['offset_in_samples'],
                                'length_in_seconds': f['length_in_seconds']} for f in iofiles['inputs']]
                 params = OrderedDict([('output', outfile), ('inputs', input_info)] + list(p.items()))
                 json.dump(params, log_stream, indent=4)


### PR DESCRIPTION
Hi, 
what do you think about disabling the quantize option for the RIR?
The RIR is relative small (file size) and IMHO it is not a good idea to store the RIR as int16.

I also added a key offset_in_samples to the metadata. Using samples as unit
avoids any serialization deserialization issues (write read of float as Human
readable is not always an identity operation), and it makes it unique (floor vs round).

I compared the slurm.pl in this repo with the slurm.pl from kaldi, and they aren't equal.
I change it back to the original code. IMHO it would be better to rename that file, when
you want to keep your environment specific changes.

This PR is a suggestion, if you don't like a change, I can remove it.
